### PR TITLE
package-bundle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,6 +140,9 @@ workflows:
           # container_gun_image_name: 'openjdk'
           # container_gun_image_tag: '11.0.3-jdk-stretch'
           container_size: 'large'
+      - gravitee/d_notifier_package_bundle:
+          requires:
+            - maven_n_git_release
 
   standalone_release_dry_run:
     when:
@@ -161,6 +164,9 @@ workflows:
           # container_gun_image_name: 'openjdk'
           # container_gun_image_tag: '11.0.3-jdk-stretch'
           container_size: 'large'
+      - gravitee/d_notifier_package_bundle:
+          requires:
+            - maven_n_git_release
 
   standalone_release_replay:
     when:
@@ -183,6 +189,9 @@ workflows:
           # container_gun_image_name: 'openjdk'
           # container_gun_image_tag: '11.0.3-jdk-stretch'
           container_size: 'large'
+      - gravitee/d_notifier_package_bundle:
+          requires:
+            - maven_n_git_release
 
   standalone_release_replay_dry_run:
     when:
@@ -205,6 +214,9 @@ workflows:
           # container_gun_image_name: 'openjdk'
           # container_gun_image_tag: '11.0.3-jdk-stretch'
           container_size: 'large'
+      - gravitee/d_notifier_package_bundle:
+          requires:
+            - maven_n_git_release
 
   # ---
   # Nighlty for all CE repositories :


### PR DESCRIPTION
Ci-dessous le lien vers la Pipeline de la standalone_release_replay en mode dry run, avec le job qui fait le package bundle, et dépose les fichiers zip de la version 1.1.0 dans le gravitee.download : 
* test 1 : https://app.circleci.com/pipelines/github/gravitee-io/gravitee-notifier-slack/27/workflows/9b676998-a2e7-4ce3-973d-44566e1589d6
* test 2 : https://app.circleci.com/pipelines/github/gravitee-io/gravitee-notifier-slack/30/workflows/5fc07f35-7c3c-4be7-b1ad-904217d03908/jobs/62

Ci-dessous le lien vers les fichiers zip deposés en mode dry-run :
 https://gravitee-dry-releases-downloads.cellar-c2.services.clever-cloud.com/index.html#plugins/notifiers/gravitee-notifier-slack/

Ci-dessous le lien vers la documentation slab :
 https://gravitee.slab.com/posts/gravitee-notifier-slack-ud73okx9