### PR TITLE
docs: remove circleci badge for this private repo

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -4,7 +4,6 @@ ifdef::env-github[]
 image:https://img.shields.io/static/v1?label=Available%20at&message=Gravitee.io&color=1EC9D2["Gravitee.io", link="https://download.gravitee.io/#plugins/notifiers/gravitee-notifier-slack/"]
 image:https://img.shields.io/badge/License-Apache%202.0-blue.svg["License", link="https://github.com/gravitee-io/gravitee-notifier-slack/blob/master/LICENSE.txt"]
 image:https://img.shields.io/badge/semantic--release-conventional%20commits-e10079?logo=semantic-release["Releases", link="https://github.com/gravitee-io/gravitee-notifier-slack/releases"]
-image:https://circleci.com/gh/gravitee-io/gravitee-notifier-slack.svg?style=svg["CircleCI", link="https://circleci.com/gh/gravitee-io/gravitee-notifier-slack"]
 image:https://f.hubspotusercontent40.net/hubfs/7600448/gravitee-github-button.jpg["Join the community forum", link="https://community.gravitee.io?utm_source=readme", height=20]
 endif::[]
 


### PR DESCRIPTION
**Description**

This is a private repo so the badge for circleCI status requires credentials. But we don't want to share credentials, even on a private repo 😉 
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.2.1`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/com/graviteesource/notifier/gravitee-notifier-slack/1.2.1/gravitee-notifier-slack-1.2.1.zip)
  <!-- Version placeholder end -->
