### PR TITLE
Update project configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,13 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@2.0
+    gravitee: gravitee-io/gravitee@5.4.2
+
+parameters:
+    jobCacheVersion:
+        description: CircleCI cache version
+        type: string
+        default: "0"
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)
@@ -22,7 +28,7 @@ workflows:
     setup_release:
         when:
             matches:
-                pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+                pattern: "/^[0-9]+\\.[0-9]+\\.[0-9]+(-(alpha|beta|rc)\\.[0-9]+)?$/"
                 value: << pipeline.git.tag >>
         jobs:
             - gravitee/setup_plugin-release-config:
@@ -32,4 +38,4 @@ workflows:
                               - /.*/
                       tags:
                           only:
-                              - /^[0-9]+\.[0-9]+\.[0-9]+$/
+                              - /^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$/

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,14 +1,3 @@
 {
-  "extends": [
-    "config:base",
-    "schedule:earlyMondays"
-  ],
-  "prConcurrentLimit": 3,
-  "rebaseWhen": "conflicted",
-  "packageRules": [
-    {
-      "matchDatasources": ["orb"],
-      "rangeStrategy": "replace"
-    }
-  ]
+    "extends": ["github>gravitee-io/renovate-config:plugin"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,3 @@ admin/console/dist
 .settings/
 .classpath
 .project
-
-gravitee-gateway-standalone/gravitee-gateway-standalone-distribution/src/main/resources/plugins/
-gravitee-gateway-standalone/gravitee-gateway-standalone-distribution/src/main/resources/logs/

--- a/pom.xml
+++ b/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
@@ -24,25 +24,22 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>20.0</version>
+        <version>23.5.0</version>
     </parent>
 
     <groupId>io.gravitee.notifier</groupId>
     <artifactId>gravitee-notifier-slack</artifactId>
-    <version>1.3.0</version>
+    <version>2.0.0-next-version-SNAPSHOT</version>
 
     <name>GraviteeSource - Notifier - Slack</name>
 
     <properties>
-        <gravitee-bom.version>1.0</gravitee-bom.version>
-        <gravitee-license-api.version>1.2.0</gravitee-license-api.version>
-        <gravitee-plugin-api.version>1.10.0</gravitee-plugin-api.version>
-        <gravitee-node-api.version>1.6.6</gravitee-node-api.version>
-        <gravitee-notifier-api.version>1.2.1</gravitee-notifier-api.version>
-        <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
+        <gravitee-bom.version>8.3.47</gravitee-bom.version>
+        <gravitee-common.version>4.9.0</gravitee-common.version>
+        <gravitee-notifier-api.version>2.0.0-alpha.1</gravitee-notifier-api.version>
 
-        <json-schema-generator-maven-plugin.version>1.3.0</json-schema-generator-maven-plugin.version>
-        <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas</json-schema-generator-maven-plugin.outputDirectory>
+        <properties-maven-plugin.version>1.3.0</properties-maven-plugin.version>
+
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>plugins/notifiers</publish-folder-path>
     </properties>
@@ -61,26 +58,11 @@
     </dependencyManagement>
 
     <dependencies>
-        <!-- GraviteeSource dependencies -->
-        <dependency>
-            <groupId>com.graviteesource.license</groupId>
-            <artifactId>gravitee-license-api</artifactId>
-            <version>${gravitee-license-api.version}</version>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- Gravitee.io -->
         <dependency>
-            <groupId>io.gravitee.plugin</groupId>
-            <artifactId>gravitee-plugin-api</artifactId>
-            <version>${gravitee-plugin-api.version}</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.gravitee.node</groupId>
-            <artifactId>gravitee-node-api</artifactId>
-            <version>${gravitee-node-api.version}</version>
+            <groupId>io.gravitee.common</groupId>
+            <artifactId>gravitee-common</artifactId>
+            <version>${gravitee-common.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -103,6 +85,12 @@
             <artifactId>slf4j-api</artifactId>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context-support</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -114,28 +102,9 @@
         </resources>
         <plugins>
             <plugin>
-                <groupId>io.gravitee.maven.plugins</groupId>
-                <artifactId>json-schema-generator-maven-plugin</artifactId>
-                <version>${json-schema-generator-maven-plugin.version}</version>
-                <executions>
-                    <execution>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>generate-json-schemas</goal>
-                        </goals>
-                        <configuration>
-                            <includes>
-                                <include>io/gravitee/notifier/slack/configuration/SlackNotifierConfiguration.class</include>
-                            </includes>
-                            <outputDirectory>${json-schema-generator-maven-plugin.outputDirectory}</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>properties-maven-plugin</artifactId>
-                <version>1.0.0</version>
+                <version>${properties-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <phase>initialize</phase>
@@ -154,7 +123,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>${maven-assembly-plugin.version}</version>
                 <configuration>
                     <appendAssemblyId>false</appendAssemblyId>
                     <descriptors>
@@ -167,23 +135,6 @@
                         <phase>package</phase>
                         <goals>
                             <goal>single</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>com.hubspot.maven.plugins</groupId>
-                <artifactId>prettier-maven-plugin</artifactId>
-                <version>0.17</version>
-                <configuration>
-                    <nodeVersion>12.13.0</nodeVersion>
-                    <prettierJavaVersion>1.6.1</prettierJavaVersion>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>check</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/src/assembly/notifier-assembly.xml
+++ b/src/assembly/notifier-assembly.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/notifier/slack/SlackNotifier.java
+++ b/src/main/java/io/gravitee/notifier/slack/SlackNotifier.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -168,11 +168,11 @@ public class SlackNotifier extends AbstractConfigurableNotifier<SlackNotifierCon
             future.completeExceptionally(
                 new NotifierException(
                     "Unable to send message to '" +
-                    SLACK_POST_MESSAGES_URL +
-                    "'. Status code: " +
-                    httpClientResponse.statusCode() +
-                    ". Message: " +
-                    httpClientResponse.statusMessage(),
+                        SLACK_POST_MESSAGES_URL +
+                        "'. Status code: " +
+                        httpClientResponse.statusCode() +
+                        ". Message: " +
+                        httpClientResponse.statusMessage(),
                     null
                 )
             );

--- a/src/main/java/io/gravitee/notifier/slack/configuration/SlackNotifierConfiguration.java
+++ b/src/main/java/io/gravitee/notifier/slack/configuration/SlackNotifierConfiguration.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/notifier/slack/request/PostMessage.java
+++ b/src/main/java/io/gravitee/notifier/slack/request/PostMessage.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -1,47 +1,43 @@
 {
-  "type" : "object",
-  "id" : "urn:jsonschema:io:gravitee:notifier:slack:configuration:SlackNotifierConfiguration",
-  "properties" : {
-    "channel": {
-      "title": "Slack channel",
-      "description": "The Slack channel to send the message to.",
-      "default": "#public",
-      "type": "string"
-    },
-    "token" : {
-      "title": "Slack token",
-      "description": "The token of the app or the bot.",
-      "type" : "string",
-      "sensitive" : true
-    },
-    "useSystemProxy": {
-      "title": "Use system proxy",
-      "description": "Use the system proxy to make request to Slack API.",
-      "type": "boolean"
-    },
-    "message" : {
-      "title": "Message",
-      "description": "The message to send to the channel",
-      "type" : "string",
-      "x-schema-form": {
-        "type": "codemirror",
-        "codemirrorOptions": {
-          "placeholder": "Put the content of the message here...",
-          "lineWrapping": true,
-          "lineNumbers": true,
-          "allowDropFileTypes": true,
-          "autoCloseTags": true,
-          "mode": {
-            "name": "markdown",
-            "highlightFormatting": true
-          }
+    "type": "object",
+    "id": "urn:jsonschema:io:gravitee:notifier:slack:configuration:SlackNotifierConfiguration",
+    "properties": {
+        "channel": {
+            "title": "Slack channel",
+            "description": "The Slack channel to send the message to.",
+            "default": "#public",
+            "type": "string"
+        },
+        "token": {
+            "title": "Slack token",
+            "description": "The token of the app or the bot.",
+            "type": "string",
+            "sensitive": true
+        },
+        "useSystemProxy": {
+            "title": "Use system proxy",
+            "description": "Use the system proxy to make request to Slack API.",
+            "type": "boolean"
+        },
+        "message": {
+            "title": "Message",
+            "description": "The message to send to the channel",
+            "type": "string",
+            "x-schema-form": {
+                "type": "codemirror",
+                "codemirrorOptions": {
+                    "placeholder": "Put the content of the message here...",
+                    "lineWrapping": true,
+                    "lineNumbers": true,
+                    "allowDropFileTypes": true,
+                    "autoCloseTags": true,
+                    "mode": {
+                        "name": "markdown",
+                        "highlightFormatting": true
+                    }
+                }
+            }
         }
-      }
-    }
-  },
-  "required": [
-    "channel",
-    "token",
-    "message"
-  ]
+    },
+    "required": ["channel", "token", "message"]
 }


### PR DESCRIPTION
**Description**

Update project configuration


BREAKING CHANGE: requires JDK 21 and notifier-api 2.0.0
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-next-version-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/notifier/gravitee-notifier-slack/2.0.0-next-version-SNAPSHOT/gravitee-notifier-slack-2.0.0-next-version-SNAPSHOT.zip)
  <!-- Version placeholder end -->
