### PR TITLE
fix: target parent 24 to not compile notifier in Java 25

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@5.5.0
+    gravitee: gravitee-io/gravitee@6.0.0
 
 parameters:
     jobCacheVersion:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# [3.0.0-alpha.1](https://github.com/gravitee-io/gravitee-notifier-slack/compare/2.0.0...3.0.0-alpha.1) (2026-03-31)
+
+
+### Features
+
+* bump orb version ([6aad843](https://github.com/gravitee-io/gravitee-notifier-slack/commit/6aad843911d42513a28e42f062a24bb1d694f925))
+* bumped AM version to 4.12.0-alpha.1 ([5b876a7](https://github.com/gravitee-io/gravitee-notifier-slack/commit/5b876a7887ca5fad1d9c159fcdce962d913acb42))
+* set maz http size in pool options ([47ef3a5](https://github.com/gravitee-io/gravitee-notifier-slack/commit/47ef3a5abd03946c7b38b174ccaa58d168791261))
+* vertx 5 upgrade, BREAKING CHANGES ([73a4a49](https://github.com/gravitee-io/gravitee-notifier-slack/commit/73a4a493840bb885af445335bfe65b5eccb6f420))
+
+
+### BREAKING CHANGES
+
+* JDK 25
+
 # [2.0.0](https://github.com/gravitee-io/gravitee-notifier-slack/compare/1.3.0...2.0.0) (2026-03-16)
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,10 +34,10 @@
     <name>GraviteeSource - Notifier - Slack</name>
 
     <properties>
-        <gravitee-bom.version>9.0.0-beta.2</gravitee-bom.version>
-        <gravitee-common.version>5.0.0-beta.1</gravitee-common.version>
+        <gravitee-bom.version>9.0.0-alpha.2</gravitee-bom.version>
+        <gravitee-common.version>5.0.0-alpha.1</gravitee-common.version>
         <gravitee-notifier-api.version>2.0.0</gravitee-notifier-api.version>
-        <gravitee-node.version>8.0.0-beta.2</gravitee-node.version>
+        <gravitee-node.version>9.0.0-alpha.1</gravitee-node.version>
 
         <properties-maven-plugin.version>1.3.0</properties-maven-plugin.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,10 +34,10 @@
     <name>GraviteeSource - Notifier - Slack</name>
 
     <properties>
-        <gravitee-bom.version>8.3.47</gravitee-bom.version>
-        <gravitee-common.version>4.9.0</gravitee-common.version>
+        <gravitee-bom.version>9.0.0-beta.2</gravitee-bom.version>
+        <gravitee-common.version>5.0.0-beta.1</gravitee-common.version>
         <gravitee-notifier-api.version>2.0.0</gravitee-notifier-api.version>
-        <gravitee-node.version>8.0.1</gravitee-node.version>
+        <gravitee-node.version>8.0.0-beta.2</gravitee-node.version>
 
         <properties-maven-plugin.version>1.3.0</properties-maven-plugin.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>io.gravitee.notifier</groupId>
     <artifactId>gravitee-notifier-slack</artifactId>
-    <version>2.0.0</version>
+    <version>3.0.0-alpha.1</version>
 
     <name>GraviteeSource - Notifier - Slack</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>24.0.0</version>
+        <version>25.0.0-alpha.1</version>
     </parent>
 
     <groupId>io.gravitee.notifier</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>25.0.0-alpha.1</version>
+        <version>24.0.2</version>
     </parent>
 
     <groupId>io.gravitee.notifier</groupId>
@@ -34,10 +34,10 @@
     <name>GraviteeSource - Notifier - Slack</name>
 
     <properties>
-        <gravitee-bom.version>9.0.0-alpha.2</gravitee-bom.version>
-        <gravitee-common.version>5.0.0-alpha.1</gravitee-common.version>
+        <gravitee-bom.version>9.0.0</gravitee-bom.version>
+        <gravitee-common.version>5.0.0</gravitee-common.version>
         <gravitee-notifier-api.version>2.0.0</gravitee-notifier-api.version>
-        <gravitee-node.version>9.0.0-alpha.1</gravitee-node.version>
+        <gravitee-node.version>9.0.0</gravitee-node.version>
 
         <properties-maven-plugin.version>1.3.0</properties-maven-plugin.version>
 

--- a/src/main/java/io/gravitee/notifier/slack/SlackNotifier.java
+++ b/src/main/java/io/gravitee/notifier/slack/SlackNotifier.java
@@ -42,6 +42,7 @@ import org.springframework.beans.factory.annotation.Value;
 public class SlackNotifier extends AbstractConfigurableNotifier<SlackNotifierConfiguration> {
 
     private static final String TYPE = "slack-notifier";
+    public final int MAX_POOL_SIZE = 1;
 
     private static final String SLACK_POST_MESSAGES_URL = "https://slack.com/api/chat.postMessage";
     private static final String HTTPS_SCHEME = "https";
@@ -120,9 +121,7 @@ public class SlackNotifier extends AbstractConfigurableNotifier<SlackNotifierCon
         );
         options.setDefaultHost(requestUri.getHost());
 
-public final int MAX_POOL_SIZE = 1;
-        PoolOptions poolOptions = PoolOptionsBuilder.build(MAX_POOL_SIZE);
-
+        PoolOptions poolOptions = new PoolOptions().setHttp1MaxSize(MAX_POOL_SIZE).setHttp2MaxSize(MAX_POOL_SIZE);
         HttpClient client = Vertx.currentContext().owner().createHttpClient(options, poolOptions);
 
         RequestOptions requestOpts = new RequestOptions()

--- a/src/main/java/io/gravitee/notifier/slack/SlackNotifier.java
+++ b/src/main/java/io/gravitee/notifier/slack/SlackNotifier.java
@@ -26,6 +26,7 @@ import io.gravitee.notifier.slack.request.PostMessage;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.*;
+import io.vertx.core.http.PoolOptions;
 import io.vertx.core.json.Json;
 import io.vertx.core.net.ProxyOptions;
 import io.vertx.core.net.ProxyType;
@@ -93,7 +94,6 @@ public class SlackNotifier extends AbstractConfigurableNotifier<SlackNotifierCon
         final HttpClientOptions options = new HttpClientOptions()
             .setSsl(ssl)
             .setTrustAll(true)
-            .setMaxPoolSize(1)
             .setKeepAlive(false)
             .setTcpKeepAlive(false)
             .setConnectTimeout(httpClientTimeout);
@@ -120,7 +120,7 @@ public class SlackNotifier extends AbstractConfigurableNotifier<SlackNotifierCon
         );
         options.setDefaultHost(requestUri.getHost());
 
-        HttpClient client = Vertx.currentContext().owner().createHttpClient(options);
+        HttpClient client = Vertx.currentContext().owner().createHttpClient(options, new PoolOptions().setMaxSize(1));
 
         RequestOptions requestOpts = new RequestOptions()
             .setURI(requestUri.getPath())

--- a/src/main/java/io/gravitee/notifier/slack/SlackNotifier.java
+++ b/src/main/java/io/gravitee/notifier/slack/SlackNotifier.java
@@ -120,7 +120,10 @@ public class SlackNotifier extends AbstractConfigurableNotifier<SlackNotifierCon
         );
         options.setDefaultHost(requestUri.getHost());
 
-        HttpClient client = Vertx.currentContext().owner().createHttpClient(options, new PoolOptions().setHttp1MaxSize(1));
+public final int MAX_POOL_SIZE = 1;
+        PoolOptions poolOptions = PoolOptionsBuilder.build(MAX_POOL_SIZE);
+
+        HttpClient client = Vertx.currentContext().owner().createHttpClient(options, poolOptions);
 
         RequestOptions requestOpts = new RequestOptions()
             .setURI(requestUri.getPath())

--- a/src/main/java/io/gravitee/notifier/slack/SlackNotifier.java
+++ b/src/main/java/io/gravitee/notifier/slack/SlackNotifier.java
@@ -120,7 +120,7 @@ public class SlackNotifier extends AbstractConfigurableNotifier<SlackNotifierCon
         );
         options.setDefaultHost(requestUri.getHost());
 
-        HttpClient client = Vertx.currentContext().owner().createHttpClient(options, new PoolOptions().setMaxSize(1));
+        HttpClient client = Vertx.currentContext().owner().createHttpClient(options, new PoolOptions().setHttp1MaxSize(1));
 
         RequestOptions requestOpts = new RequestOptions()
             .setURI(requestUri.getPath())


### PR DESCRIPTION
 bump the dependency to use final release
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.0-prepare-4-12-release-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/notifier/gravitee-notifier-slack/3.0.0-prepare-4-12-release-SNAPSHOT/gravitee-notifier-slack-3.0.0-prepare-4-12-release-SNAPSHOT.zip)
  <!-- Version placeholder end -->
